### PR TITLE
Purity now not used in shear [version:1.0.10]

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,11 +2,11 @@ coverage:
   status:
     project:
       default:
-        threshold: 1%    # allow up to 1% drop without failing
+        threshold: 0.1%    # allow up to 1% drop without failing
     patch:
       default:
         target: auto     # compare patch coverage to base, not project total
-        threshold: 1%
+        threshold: 0.1%
 
 ignore:
   - "docs/**"

--- a/crow/__init__.py
+++ b/crow/__init__.py
@@ -8,4 +8,4 @@ from .recipes.binned_exact import ExactBinnedClusterRecipe
 from .recipes.binned_grid import GridBinnedClusterRecipe
 from .recipes.binned_parent import BinnedClusterRecipe
 
-__version__ = "1.0.9"
+__version__ = "1.0.10"

--- a/crow/recipes/binned_exact.py
+++ b/crow/recipes/binned_exact.py
@@ -68,6 +68,9 @@ class ExactBinnedClusterRecipe(BinnedClusterRecipe):
 
         self.integrator = NumCosmoIntegrator()
 
+        # placeholder: always ignore purity for shear computations
+        self.shear_purity = None
+
     def setup(self):
         pass
 
@@ -326,11 +329,13 @@ class ExactBinnedClusterRecipe(BinnedClusterRecipe):
                     z=z,
                     radius_center=radius_center,
                 )
-                if self.purity == None:
+                # TODO: Handle purity in shear computation properly
+                # For now, always ignore purity (self.shear_purity = None by default)
+                if self.shear_purity is None:
                     assert (
                         len(mass_proxy) == 2
                     ), "mass_proxy with no purity should be size 2"
-                    prediction *= self._mass_distribution_distribution(
+                    prediction *= self.mass_distribution.distribution(
                         mass, z, (mass_proxy[0], mass_proxy[1])
                     )
                 else:
@@ -368,7 +373,7 @@ class ExactBinnedClusterRecipe(BinnedClusterRecipe):
             mass = int_args[:, 0]
             z = int_args[:, 1]
 
-            if self.purity == None:
+            if self.shear_purity is None:
                 mass_proxy = np.array([extra_args[0], extra_args[1]])
                 sky_area = extra_args[2]
                 radius_center = extra_args[3]
@@ -430,7 +435,7 @@ class ExactBinnedClusterRecipe(BinnedClusterRecipe):
         assert len(log_proxy_edges) == 2, "log_proxy_edges should be size 2"
         assert len(z_edges) == 2, "z_edges should be size 2"
 
-        if self.purity == None:
+        if self.shear_purity is None:
             self.integrator.integral_bounds = [
                 self.mass_interval,
                 z_edges,

--- a/crow/recipes/binned_grid.py
+++ b/crow/recipes/binned_grid.py
@@ -330,6 +330,7 @@ class GridBinnedClusterRecipe(BinnedClusterRecipe):
         probe_kernel,  # must be (n_proxy, n_z, n_mass, ...)
         integ_arrays,
         sky_area: float,
+        ignore_purity: bool = False,
     ) -> float:
         """Evaluate the theory prediction for this cluster recipe using triple Simpson integration."""
         """
@@ -384,13 +385,17 @@ class GridBinnedClusterRecipe(BinnedClusterRecipe):
             integ_arrays["log_proxy"]["points"],
             purity_key,
         )
+        if ignore_purity:
+            purity_factor = 1.0
+        else:
+            purity_factor = purity_grid[:, :, np.newaxis]
 
         # main kernel: (n_proxy, n_z, n_mass)
         main_kernel_grid = (
             hmf_grid[np.newaxis, :, :]
             * mass_richness_grid
             * completeness_grid[np.newaxis, :, :]
-            / purity_grid[:, :, np.newaxis]
+            / purity_factor
         )
 
         # reshape it to match probe_kernel
@@ -562,9 +567,12 @@ class GridBinnedClusterRecipe(BinnedClusterRecipe):
         # integrate
         ###########
 
+        # TODO: Handle purity in shear computation properly
+        # For now, always ignore purity
         shear = self._evaluate_theory_prediction_generic(
             probe_kernel,
             integ_arrays,
             sky_area,
+            ignore_purity=True,
         )
         return shear

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -165,15 +165,13 @@ index_toc = ""
 subprocess.run("cp source/index_body.rst index.rst", shell=True)
 with open("index.rst", "a") as indexfile:
     indexfile.write(index_toc)
-    indexfile.write(
-        """
+    indexfile.write("""
 .. toctree::
    :maxdepth: 1
    :caption: Reference
 
    api
-"""
-    )
+""")
 
 # -- API table of contents -----------------------------------------------
 apitoc = """API Documentation

--- a/tests/test_recipe_binned_shear_profile.py
+++ b/tests/test_recipe_binned_shear_profile.py
@@ -468,6 +468,8 @@ def test_shear_respects_completeness_and_purity_effects(
     with_comp = get_base_binned_grid(comp_dist, None, True)
     print("with_comp:", with_comp)
     with_pur = get_base_binned_grid(None, pur_dist, True)
+    ## For now purity is a placeholder for shear and we force here for checks
+    with_pur.shear_purity = True
     z_edges = (0.5, 0.8)
     mass_proxy_edges = (2, 5)
     radii = np.atleast_1d(1.5)

--- a/tests/test_recipe_binned_shear_profile.py
+++ b/tests/test_recipe_binned_shear_profile.py
@@ -468,8 +468,10 @@ def test_shear_respects_completeness_and_purity_effects(
     with_comp = get_base_binned_grid(comp_dist, None, True)
     print("with_comp:", with_comp)
     with_pur = get_base_binned_grid(None, pur_dist, True)
-    ## For now purity is a placeholder for shear and we force here for checks
-    with_pur.shear_purity = True
+    ## For now purity is a placeholder. Adding purity for the grid does nothing
+    exact_pur = get_base_binned_exact(None, pur_dist, True)
+    ## Here we force the purity computation for the exact
+    exact_pur.shear_purity = True
     z_edges = (0.5, 0.8)
     mass_proxy_edges = (2, 5)
     radii = np.atleast_1d(1.5)
@@ -485,6 +487,9 @@ def test_shear_respects_completeness_and_purity_effects(
     pur_val = with_pur.evaluate_theory_prediction_lensing_profile(
         z_edges, mass_proxy_edges, radii, sky_area, average_on
     )
+    pur_val_exact = exact_pur.evaluate_theory_prediction_lensing_profile(
+        z_edges, mass_proxy_edges, radii, sky_area, average_on
+    )
 
     # completeness should not increase the predicted average shear (it reduces effective counts/kernel)
     assert comp_val <= base_val + 1e-12
@@ -494,3 +499,4 @@ def test_shear_respects_completeness_and_purity_effects(
 
     assert np.isfinite(pur_val)
     assert pur_val >= 0.0
+    assert pur_val_exact >= 0.0


### PR DESCRIPTION
See attached issue for a description of the problem. THis PR makes purity never used in shear, so we are able to use one recipe with completeness and purity for counts and the same recipe will return shear only with completeness