### PR TITLE
Fix stale _clmm_cosmo in ClusterShearProfile on cosmology update [version:1.0.11]

### DIFF
--- a/crow/__init__.py
+++ b/crow/__init__.py
@@ -8,4 +8,4 @@ from .recipes.binned_exact import ExactBinnedClusterRecipe
 from .recipes.binned_grid import GridBinnedClusterRecipe
 from .recipes.binned_parent import BinnedClusterRecipe
 
-__version__ = "1.0.10"
+__version__ = "1.0.11"

--- a/crow/cluster_modules/shear_profile.py
+++ b/crow/cluster_modules/shear_profile.py
@@ -48,6 +48,25 @@ class ClusterShearProfile(ClusterAbundance):
     shear integrand.
     """
 
+    @property
+    def cosmo(self) -> Cosmology | None:
+        """The cosmology used to predict the cluster shear profile."""
+        return self._cosmo
+
+    @cosmo.setter
+    def cosmo(self, cosmo: Cosmology) -> None:
+        """Update the shear profile calculation with a new cosmology.
+
+        Overrides `ClusterAbundance.cosmo` to also refresh the CLMM-wrapped
+        cosmology used internally for the delta sigma / shear calculations.
+        Without this, `_clmm_cosmo` stays pinned to whatever cosmology was
+        passed at construction time, so predictions silently ignore any
+        cosmology update (e.g. from a sampler) after the object is created.
+        """
+        self._cosmo = cosmo
+        self._hmf_cache: dict[tuple[float, float], float] = {}
+        self._clmm_cosmo = clmm.Cosmology(be_cosmo=cosmo, validate_input=False)
+
     def __init__(
         self,
         cosmo: Cosmology,
@@ -88,8 +107,6 @@ class ClusterShearProfile(ClusterAbundance):
 
         self.two_halo_term = two_halo_term
         self.boost_factor = boost_factor
-
-        self._clmm_cosmo = clmm.Cosmology(be_cosmo=self._cosmo, validate_input=False)
 
         self._beta_parameters = None
         self._beta_s_mean_interp = None

--- a/tests/test_cluster_shear_profile.py
+++ b/tests/test_cluster_shear_profile.py
@@ -68,6 +68,33 @@ def test_cluster_update_ingredients(
         assert cluster._hmf_cache == {}  # pylint: disable=protected-access
 
 
+def test_cluster_shear_profile_cosmo_update_refreshes_clmm_cosmo(
+    cluster_deltasigma_profile: ClusterShearProfile,
+):
+    """cosmo reassignment must propagate to the internal CLMM cosmology.
+
+    Regression test: `_clmm_cosmo` used to be built once in `__init__` and
+    never refreshed when `.cosmo` was reassigned later (e.g. by a sampler),
+    so delta sigma predictions silently kept using the construction-time
+    cosmology no matter what was sampled.
+    """
+    new_cosmo = pyccl.Cosmology(
+        Omega_c=0.22,
+        Omega_b=0.0448,
+        h=0.71,
+        sigma8=0.8,
+        n_s=0.963,
+    )
+    assert new_cosmo["Omega_c"] != _TEST_COSMO["Omega_c"]
+
+    cluster_deltasigma_profile.cosmo = new_cosmo
+
+    # pylint: disable=protected-access
+    assert cluster_deltasigma_profile._clmm_cosmo.be_cosmo["Omega_c"] == pytest.approx(
+        new_cosmo["Omega_c"]
+    )
+
+
 def test_cluster_deltasigma_profile_init(
     cluster_deltasigma_profile: ClusterShearProfile,
 ):


### PR DESCRIPTION
ClusterShearProfile inherited ClusterAbundance.cosmo, whose setter only updated self._cosmo. The CLMM-wrapped cosmology (self._clmm_cosmo), which is what the delta sigma / shear calculations actually use, was built once in __init__ and never refreshed. Any cosmology reassignment after construction (e.g. from the FIrecrown sampler via UpdatableClusterObjects) silently left shear predictions pinned to the construction-time cosmology.

Overrides the cosmo property in ClusterShearProfile to also rebuild _clmm_cosmo on every update, and adds a regression test.